### PR TITLE
Improve Flask leaderboard with SQLite and template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+leaderboard.db
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-#CW leetcode_private_leaderboard
+# LeetCode Private Leaderboard
+
+This repository contains a small Flask app for a private LeetCode leaderboard. It relies on the public API hosted at [alfa-leetcode-api](https://github.com/alfaarghya/alfa-leetcode-api).
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the server:
+   ```bash
+   python leaderboard.py
+   ```
+
+The application automatically creates a SQLite database (`leaderboard.db`) to store registered users.
+
+Open `http://localhost:5000/` to view the leaderboard and add your LeetCode ID.

--- a/leaderboard.py
+++ b/leaderboard.py
@@ -1,0 +1,70 @@
+import os
+import sqlite3
+import requests
+from flask import Flask, request, redirect, render_template, g
+
+DB_PATH = 'leaderboard.db'
+app = Flask(__name__)
+
+def get_db():
+    if 'db' not in g:
+        g.db = sqlite3.connect(DB_PATH)
+        g.db.execute('CREATE TABLE IF NOT EXISTS users (username TEXT PRIMARY KEY)')
+    return g.db
+
+@app.teardown_appcontext
+def close_db(exception=None):
+    db = g.pop('db', None)
+    if db is not None:
+        db.close()
+
+def get_users():
+    cur = get_db().execute('SELECT username FROM users')
+    rows = cur.fetchall()
+    return [r[0] for r in rows]
+
+def add_user_db(username):
+    db = get_db()
+    db.execute('INSERT OR IGNORE INTO users (username) VALUES (?)', (username,))
+    db.commit()
+
+
+def fetch_user_stats(username):
+    url = f"https://alfa-leetcode-api.vercel.app/api/{username}"
+    resp = requests.get(url, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+    return {
+        'username': username,
+        'totalSolved': data.get('totalSolved', 0),
+        'ranking': data.get('ranking')
+    }
+
+
+def update_stats(users):
+    stats = []
+    for user in users:
+        try:
+            stats.append(fetch_user_stats(user))
+        except Exception:
+            continue
+    return sorted(stats, key=lambda x: x['totalSolved'], reverse=True)
+
+
+@app.route('/', methods=['GET'])
+def leaderboard():
+    users = get_users()
+    stats = update_stats(users)
+    return render_template('leaderboard.html', stats=stats)
+
+
+@app.route('/add', methods=['POST'])
+def add_user():
+    username = request.form.get('username')
+    if username:
+        add_user_db(username)
+    return redirect('/')
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask==3.0.0
+requests==2.31.0

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>LeetCode Leaderboard</title>
+  <style>
+    body { font-family: Arial, sans-serif; padding: 2em; }
+    table { border-collapse: collapse; width: 60%; margin-bottom: 2em; }
+    th, td { border: 1px solid #ccc; padding: 0.5em 1em; text-align: left; }
+    th { background: #f0f0f0; }
+    form input { padding: 0.5em; }
+    form button { padding: 0.5em 1em; }
+  </style>
+</head>
+<body>
+  <h1>Leaderboard</h1>
+  <table>
+    <tr><th>#</th><th>User</th><th>Solved</th></tr>
+    {% for row in stats %}
+    <tr><td>{{ loop.index }}</td><td>{{ row.username }}</td><td>{{ row.totalSolved }}</td></tr>
+    {% endfor %}
+  </table>
+  <form method="post" action="/add">
+    <input name="username" placeholder="LeetCode ID" required>
+    <button type="submit">Join</button>
+  </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- switch to SQLite database for storing usernames
- add simple HTML template for a nicer leaderboard interface
- document database creation in README
- ignore generated DB file

## Testing
- `python -m py_compile leaderboard.py`


------
https://chatgpt.com/codex/tasks/task_e_686c1c46efc08328954a4da469d1a48b